### PR TITLE
speed up closest_pow()

### DIFF
--- a/src/utils/helpers.rs
+++ b/src/utils/helpers.rs
@@ -9,10 +9,9 @@ pub fn modulo(num: u128, divisor: u128) -> usize {
 }
 
 /// find the closest power of 2 that is >= bit_arr_len
-/// expected number of items should be considered carefully especially if memory usage is important
+#[inline(always)]
 pub fn closest_pow(n: u64) -> u64{
-    let res: u64 = 1;
-    res << (64 - n.leading_zeros() - n.is_power_of_two() as u32)
+    1 << (64 - n.leading_zeros() - n.is_power_of_two() as u32)
 }
 
 pub fn load_seeds(filename: &str) -> Option<Vec<u32>>{

--- a/src/utils/helpers.rs
+++ b/src/utils/helpers.rs
@@ -11,13 +11,9 @@ pub fn modulo(num: u128, divisor: u128) -> usize {
 /// find the closest power of 2 that is >= bit_arr_len
 /// expected number of items should be considered carefully especially if memory usage is important
 pub fn closest_pow(n: u64) -> u64{
-    let mut res: u64 = 2;
-    while res < n{
-        res = res << 1;
-    }
-    res
+    let res: u64 = 1;
+    res << (64 - n.leading_zeros() - n.is_power_of_two() as u32)
 }
-
 
 pub fn load_seeds(filename: &str) -> Option<Vec<u32>>{
     let file_contents = std::fs::read_to_string(filename);
@@ -72,8 +68,11 @@ mod tests{
     fn closest_pow_test(){
         assert_eq!(closest_pow(7), 8);
         assert_eq!(closest_pow(2), 2);
+        assert_eq!(closest_pow(256), 256);
         assert_eq!(closest_pow(120), 128);
         assert_eq!(closest_pow(240), 256);
+        assert_eq!(closest_pow(1000), 1024);
+        assert_eq!(closest_pow(1024), 1024);
     }
     #[test]
     fn writing_and_reading_seeds(){


### PR DESCRIPTION
The while loop shifts multiple times, this shifts only once (or so I think), it also doesn't do comparisons (on the surface at least), speeding up the computation by a factor of 2 if not more in some cases (blazingly fast 🔥).

